### PR TITLE
Tweak conversion mechanics to be more explicit and safe.

### DIFF
--- a/packages/core/src/Currency.ts
+++ b/packages/core/src/Currency.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { optionalIgnoringNull } from "./zodUtils.js";
 
 export const CurrencySchema = z.object({
   /**
@@ -35,13 +34,15 @@ export const CurrencySchema = z.object({
   maxSendable: z.number(),
 
   /**
-   * Number of digits after the decimal point for display on the sender side. For example,
-   * in USD, by convention, there are 2 digits for cents - $5.95. in this case, `decimals`
-   * would be 2. Note that the multiplier is still always in the smallest unit (cents). This field
-   * is only for display purposes. The sender should assume zero if this field is omitted, unless
-   * they know the proper display format of the target currency.
+   * The number of digits after the decimal point for display on the sender side, and to add clarity
+   * around what the "smallest unit" of the currency is. For example, in USD, by convention, there are 2 digits for
+   * cents - $5.95. In this case, `decimals` would be 2. Note that the multiplier is still always in the smallest
+   * unit (cents). In addition to display purposes, this field can be used to resolve ambiguity in what the multiplier
+   * means. For example, if the currency is "BTC" and the multiplier is 1000, really we're exchanging in SATs, so
+   * `decimals` would be 8.
+   * For details on edge cases and examples, see https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md.
    */
-  decimals: optionalIgnoringNull(z.number()),
+  decimals: z.number(),
 });
 
 export type Currency = z.infer<typeof CurrencySchema>;

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -81,10 +81,10 @@ describe("uma", () => {
       nonce: "12345",
       timestamp: expectedTime,
       vaspDomain: "vasp1",
-      umaVersion: "0.1",
+      umaVersion: "0.2",
     };
     const urlString =
-      "https://vasp2/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=" +
+      "https://vasp2/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=" +
       timeSec;
     const urlObj = new URL(urlString);
     const query = parseLnurlpRequest(urlObj);
@@ -93,14 +93,14 @@ describe("uma", () => {
 
   it("validates uma queries", () => {
     const umaQuery =
-      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678";
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678";
     expect(isUmaLnurlpQuery(new URL(umaQuery))).toBeTruthy();
   });
 
   it("returns expected result for missing query params", () => {
     // Missing signature
     let url = new URL(
-      "https://vasp2.com/.well-known/lnurlp/bob?nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/.well-known/lnurlp/bob?nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
@@ -112,25 +112,25 @@ describe("uma", () => {
 
     // Missing nonce
     url = new URL(
-      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
     // Missing vaspDomain
     url = new URL(
-      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&umaVersion=0.1&nonce=12345&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&umaVersion=0.2&nonce=12345&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
     url = new URL(
-      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&umaVersion=0.1&nonce=12345&vaspDomain=vasp1.com&timestamp=12345678",
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&umaVersion=0.2&nonce=12345&vaspDomain=vasp1.com&timestamp=12345678",
     );
     // IsSubjectToTravelRule is optional
     expect(isUmaLnurlpQuery(url)).toBe(true);
 
     // Missing timestamp
     url = new URL(
-      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true",
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
@@ -141,17 +141,17 @@ describe("uma", () => {
 
   it("should be invalid uma query when url path is invalid", () => {
     let url = new URL(
-      "https://vasp2.com/.well-known/lnurla/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/.well-known/lnurla/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
     url = new URL(
-      "https://vasp2.com/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
 
     url = new URL(
-      "https://vasp2.com/?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678",
+      "https://vasp2.com/?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.2&isSubjectToTravelRule=true&timestamp=12345678",
     );
     expect(isUmaLnurlpQuery(url)).toBe(false);
   });
@@ -208,7 +208,7 @@ describe("uma", () => {
       "hex",
     );
     const queryUrl = new URL(
-      "https://uma.jeremykle.in/.well-known/lnurlp/$jeremy?isSubjectToTravelRule=true&nonce=2734010273&signature=30450220694fce49a32c81a58ddb0090ebdd4c7ff3a1e277d28570c61bf2b8274b5d8286022100fe6f0318579e12726531c8a63aea6a94f59f46b7679f970df33f7750a0d88f36&timestamp=1701461443&umaVersion=0.1&vaspDomain=api.ltng.bakkt.com",
+      "https://uma.jeremykle.in/.well-known/lnurlp/$jeremy?isSubjectToTravelRule=true&nonce=2734010273&signature=30450220694fce49a32c81a58ddb0090ebdd4c7ff3a1e277d28570c61bf2b8274b5d8286022100fe6f0318579e12726531c8a63aea6a94f59f46b7679f970df33f7750a0d88f36&timestamp=1701461443&umaVersion=0.2&vaspDomain=api.ltng.bakkt.com",
     );
 
     const query = parseLnurlpRequest(queryUrl);

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -138,10 +138,8 @@ export async function fetchPublicKeyForVasp({
   const response = await fetch(
     scheme + vaspDomain + "/.well-known/lnurlpubkey",
   );
-  if (response.status != 200) {
-    if (response.status !== 200) {
-      return Promise.reject(new Error("invalid response from VASP"));
-    }
+  if (response.status !== 200) {
+    return Promise.reject(new Error("invalid response from VASP"));
   }
   const pubKeyResponse = await response.json();
   cache.addPublicKeyForVasp(vaspDomain, pubKeyResponse);

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,5 +1,5 @@
 export const MAJOR_VERSION = 0;
-export const MINOR_VERSION = 1;
+export const MINOR_VERSION = 2;
 
 export const UmaProtocolVersion = `${MAJOR_VERSION}.${MINOR_VERSION}`;
 


### PR DESCRIPTION
 - Make the decimals field on Currency required and change its description to include more details about its use. See https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md for details on why this is needed.

NOTE: For JS, this isn't a breaking change, but it is for other languages that need to switch from int to float for the multiplier field. Given that we're not yet at UMA 1.0, I'm bumping the protocol version here to 0.2 to indicate the bump and to be able to tell what version the counterparty is using for debugging.