### PR TITLE
Fix version future-proofing with isUmaLnurlpQuery.

### DIFF
--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -161,6 +161,17 @@ describe("uma", () => {
     expect(isUmaLnurlpQuery(url)).toBe(false);
   });
 
+  it("future uma versions are still UMA queries", () => {
+    const umaQuery =
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=100.0&isSubjectToTravelRule=true&timestamp=12345678";
+    expect(isUmaLnurlpQuery(new URL(umaQuery))).toBeTruthy();
+
+    // Maybe the params can change in a future version.
+    const umaQueryMissingParams =
+      "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&umaVersion=100.0&isSubjectToTravelRule=true&timestamp=12345678";
+    expect(isUmaLnurlpQuery(new URL(umaQueryMissingParams))).toBeTruthy();
+  });
+
   it("should validate valid uma addresses", () => {
     expect(isValidUmaAddress("$bob@vasp-domain.com")).toBe(true);
     expect(isValidUmaAddress("$BOb@vasp-domain.com")).toBe(true);

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -56,6 +56,20 @@ export function parseLnurlpRequest(url: URL) {
   const umaVersion = query.get("umaVersion");
   const timestamp = query.get("timestamp");
 
+  const pathParts = url.pathname.split("/");
+  if (
+    pathParts.length != 4 ||
+    pathParts[1] != ".well-known" ||
+    pathParts[2] != "lnurlp"
+  ) {
+    throw new Error("invalid request path");
+  }
+  const receiverAddress = pathParts[3] + "@" + url.host;
+
+  if (umaVersion && !isVersionSupported(umaVersion)) {
+    throw new UnsupportedVersionError(umaVersion);
+  }
+
   if (!vaspDomain || !signature || !nonce || !timestamp || !umaVersion) {
     throw new Error(
       "missing uma query parameters. vaspDomain, umaVersion, signature, nonce, and timestamp are required",
@@ -65,20 +79,6 @@ export function parseLnurlpRequest(url: URL) {
   const timestampUnixSeconds = parseInt(timestamp, 10);
   /* Date expects milliseconds: */
   const timestampAsTime = new Date(timestampUnixSeconds * 1000);
-
-  const pathParts = url.pathname.split("/");
-  if (
-    pathParts.length != 4 ||
-    pathParts[1] != ".well-known" ||
-    pathParts[2] != "lnurlp"
-  ) {
-    throw new Error("invalid uma request path");
-  }
-  const receiverAddress = pathParts[3] + "@" + url.host;
-
-  if (!isVersionSupported(umaVersion)) {
-    throw new UnsupportedVersionError(umaVersion);
-  }
 
   return {
     vaspDomain,


### PR DESCRIPTION
Future versions of UMA may change fields in this request, etc. so treating a parse failure as "non-uma" isn't the right behavior. We should throw the UnsupportedVersionException before trying to parse other fields.