### PR TITLE
Avoid defaulting to SAT for empty sending currency.

### DIFF
--- a/packages/core/src/protocol/PayRequest.ts
+++ b/packages/core/src/protocol/PayRequest.ts
@@ -153,8 +153,8 @@ export class PayRequest {
       };
     }
     const amountString = !this.sendingAmountCurrencyCode
-        ? this.amount.toString()
-        : `${this.amount}.${this.sendingAmountCurrencyCode}`;
+      ? this.amount.toString()
+      : `${this.amount}.${this.sendingAmountCurrencyCode}`;
     return {
       convert: this.receivingCurrencyCode,
       amount: amountString,
@@ -189,7 +189,7 @@ export class PayRequest {
 
   static fromSchema(schema: z.infer<typeof PayRequestSchema>): PayRequest {
     let amount: number;
-    let sendingAmountCurrencyCode: string|undefined;
+    let sendingAmountCurrencyCode: string | undefined;
     const amountFieldStr = schema.amount.toString();
     if (!amountFieldStr.includes(".")) {
       amount = z.coerce.number().int().parse(amountFieldStr);

--- a/packages/core/src/protocol/PayRequest.ts
+++ b/packages/core/src/protocol/PayRequest.ts
@@ -152,8 +152,7 @@ export class PayRequest {
         comment: this.comment,
       };
     }
-    const amountString =
-      this.sendingAmountCurrencyCode == "SAT" || !this.sendingAmountCurrencyCode
+    const amountString = !this.sendingAmountCurrencyCode
         ? this.amount.toString()
         : `${this.amount}.${this.sendingAmountCurrencyCode}`;
     return {
@@ -190,11 +189,11 @@ export class PayRequest {
 
   static fromSchema(schema: z.infer<typeof PayRequestSchema>): PayRequest {
     let amount: number;
-    let sendingAmountCurrencyCode: string;
+    let sendingAmountCurrencyCode: string|undefined;
     const amountFieldStr = schema.amount.toString();
     if (!amountFieldStr.includes(".")) {
       amount = z.coerce.number().int().parse(amountFieldStr);
-      sendingAmountCurrencyCode = "SAT";
+      sendingAmountCurrencyCode = undefined;
     } else if (amountFieldStr.split(".").length > 2) {
       throw new Error(
         "invalid amount string. Cannot contain more than one period. Example: '5000' for SAT or '5.USD' for USD.",

--- a/packages/core/src/tests/protocol.test.ts
+++ b/packages/core/src/tests/protocol.test.ts
@@ -57,7 +57,7 @@ describe("uma protocol", () => {
   it("should parse valid non-uma payreq", async () => {
     const payReq = PayRequest.fromJson(JSON.stringify({ amount: 100 }));
     expect(payReq.amount).toBe(100);
-    expect(payReq.sendingAmountCurrencyCode).toBe("SAT");
+    expect(payReq.sendingAmountCurrencyCode).toBeUndefined();
     expect(payReq.receivingCurrencyCode).toBeUndefined();
     expect(payReq.payerData).toBeUndefined();
     expect(payReq.isUma()).toBe(false);
@@ -95,7 +95,7 @@ describe("uma protocol", () => {
       }),
     );
     expect(payReq.amount).toBe(100);
-    expect(payReq.sendingAmountCurrencyCode).toBe("SAT");
+    expect(payReq.sendingAmountCurrencyCode).toBeUndefined();
     expect(payReq.receivingCurrencyCode).toBe("USD");
   });
 

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -588,7 +588,7 @@ describe("uma", () => {
       utxoCallback: "/api/lnurl/utxocallback?txid=1234",
       umaMajorVersion: 1,
     });
-    expect(payreq.sendingAmountCurrencyCode).toBe("SAT");
+    expect(payreq.sendingAmountCurrencyCode).toBeUndefined();
     expect(payreq.receivingCurrencyCode).toBe("USD");
 
     const invoiceCreator = {

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -423,7 +423,7 @@ export async function getPayRequest({
   );
   const sendingAmountCurrencyCode = isAmountInReceivingCurrency
     ? receivingCurrencyCode
-    : "SAT";
+    : undefined;
 
   return new PayRequest(
     amount,
@@ -595,9 +595,7 @@ export async function getPayReqResponse({
     receiverFeesMillisats,
   });
 
-  const isSendingAmountInMsats =
-    !request.sendingAmountCurrencyCode ||
-    request.sendingAmountCurrencyCode === "SAT";
+  const isSendingAmountInMsats = !request.sendingAmountCurrencyCode
 
   if (
     !isSendingAmountInMsats &&

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -595,7 +595,7 @@ export async function getPayReqResponse({
     receiverFeesMillisats,
   });
 
-  const isSendingAmountInMsats = !request.sendingAmountCurrencyCode
+  const isSendingAmountInMsats = !request.sendingAmountCurrencyCode;
 
   if (
     !isSendingAmountInMsats &&


### PR DESCRIPTION
In practice, it's actually msats, not sats. This breaks the amount of the created invoice.