### PR TITLE
Add button customizability, wrap web component in react component

### DIFF
--- a/examples/html/index.html
+++ b/examples/html/index.html
@@ -4,6 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UMA Auth Client html demo</title>
+    <style>
+      :root {
+        --uma-connect-background: #7366C5;
+        --uma-connect-radius: 8px;
+        --uma-connect-padding-x: 32px;
+        --uma-connect-padding-y: 16px;
+        --uma-connect-text-color: #F9F9F9;
+        --uma-connect-font-family: Arial;
+        --uma-connect-font-size: 16px;
+        --uma-connect-font-weight: 600;
+      }
+    </style>
   </head>
   <body>
     <h1>UMA Auth Client html demo</h1>

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -16,7 +16,18 @@ function App() {
           <Body content="Click the UMA Connect button to get started." />
         </Intro>
       </Section>
-      <UmaConnectButton />
+      <UmaConnectButton
+        style={{
+          "--uma-connect-background": "#7366C5",
+          "--uma-connect-radius": "8px",
+          "--uma-connect-padding-x": "32px",
+          "--uma-connect-padding-y": "16px",
+          "--uma-connect-text-color": "#F9F9F9",
+          "--uma-connect-font-family": "Arial",
+          "--uma-connect-font-size": "16px",
+          "--uma-connect-font-weight": "600",
+        }}
+      />
     </Main>
   );
 }

--- a/packages/uma-auth-client/package.json
+++ b/packages/uma-auth-client/package.json
@@ -31,24 +31,22 @@
     "format": "prettier src --check"
   },
   "dependencies": {
-    "@babel/core": "^7.21.4",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@lightsparkdev/ui": "^1.0.3",
-    "babel-loader": "^9.1.2",
-    "babel-plugin-named-asset-import": "^0.3.8",
-    "babel-preset-react-app": "^10.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.25.1",
-    "vite-plugin-dts": "^4.0.1"
+    "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.11.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "babel-loader": "^9.1.2",
+    "babel-plugin-named-asset-import": "^0.3.8",
+    "babel-preset-react-app": "^10.0.1",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.3",
     "eslint-plugin-react-hooks": "^4.6.2",
@@ -56,6 +54,7 @@
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
     "typescript": "^5.0.0",
-    "vite": "^5.3.4"
+    "vite": "^5.3.4",
+    "vite-plugin-dts": "^4.0.1"
   }
 }

--- a/packages/uma-auth-client/src/components/UmaConnectButton.tsx
+++ b/packages/uma-auth-client/src/components/UmaConnectButton.tsx
@@ -1,26 +1,50 @@
-import { ThemeProvider } from "@emotion/react";
-import { Button } from "@lightsparkdev/ui/components";
-import { themes } from "@lightsparkdev/ui/styles/themes";
-import { GlobalStyles } from "src/GlobalStyles";
+import { css } from "@emotion/css";
+import styled from "@emotion/styled";
+import { Icon, UnstyledButton } from "@lightsparkdev/ui/components";
+import defineWebComponent from "src/utils/defineWebComponent";
 
-export const UmaConnectButton = () => {
+export const TAG_NAME = "uma-connect-button";
+
+const UmaConnectButton = () => {
   const clientId = "1";
-  const redirectUri = "http://localhost:3000";
+  const redirectUri = "http://localhost:3001";
   const responseType = "code";
   const codeChallenge = "1234";
   const codeChallengeMethod = "S256";
 
   return (
-    <ThemeProvider theme={themes.umameDocsLight}>
-      <GlobalStyles />
-      <Button
-        icon="Uma"
-        text="Connect"
-        kind="primary"
-        onClick={() =>
-          (window.location.href = `http://localhost:3000/apps/new?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}&required_commands=send_payments&optional_commands=read_balance,read_transactions&budget=10.USD%2Fmonthly&expiration_period=year`)
-        }
+    <Button
+      onClick={() =>
+        (window.location.href = `http://localhost:3000/apps/new?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}&required_commands=send_payments&optional_commands=read_balance,read_transactions&budget=10.USD%2Fmonthly&expiration_period=year`)
+      }
+    >
+      <Icon
+        name="Uma"
+        width={36}
+        className={css`
+          color: var(--uma-connect-text-color, #ffffff);
+        `}
       />
-    </ThemeProvider>
+      Connect
+    </Button>
   );
 };
+
+const Button = styled(UnstyledButton)`
+  background-color: var(--uma-connect-background, #0068c9);
+  border-radius: var(--uma-connect-radius, 999px);
+  padding-left: var(--uma-connect-padding-x, 32px);
+  padding-right: var(--uma-connect-padding-x, 32px);
+  padding-top: var(--uma-connect-padding-y, 16px);
+  padding-bottom: var(--uma-connect-padding-y, 16px);
+  color: var(--uma-connect-text-color, #ffffff);
+  font-family: var(--uma-connect-font-family, "Manrope");
+  font-size: var(--uma-connect-font-size, 16px);
+  font-weight: var(--uma-connect-font-weight, 700);
+`;
+
+defineWebComponent(TAG_NAME, UmaConnectButton);
+
+export const UmaConnectButtonWebComponent = (props: Record<string, any>) => (
+  <uma-connect-button {...props} />
+);

--- a/packages/uma-auth-client/src/main.tsx
+++ b/packages/uma-auth-client/src/main.tsx
@@ -1,6 +1,18 @@
-import { UmaConnectButton } from "./components/UmaConnectButton";
-import defineWebComponent from "./utils/defineWebComponent";
+import * as React from "react";
+import {
+  TAG_NAME as UmaConnectButtonTagName,
+  UmaConnectButtonWebComponent,
+} from "./components/UmaConnectButton";
 
-defineWebComponent("uma-connect-button", UmaConnectButton);
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      [UmaConnectButtonTagName]: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement>,
+        HTMLElement
+      >;
+    }
+  }
+}
 
-export { UmaConnectButton };
+export { UmaConnectButtonWebComponent as UmaConnectButton };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,7 +4349,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@uma-sdk/uma-auth-client@workspace:packages/uma-auth-client"
   dependencies:
-    "@babel/core": ^7.21.4
     "@emotion/babel-plugin": ^11.11.0
     "@emotion/css": ^11.11.2
     "@emotion/react": ^11.11.4


### PR DESCRIPTION
- adds css variables to customize button appearance
- wraps web component in react component when importing from a react app. This is because emotion would otherwise override page styles with its dynamic styles, so I'm just reusing the encapsulation provided by the web component/shadow dom logic
- moves some dependencies to dev dependencies

![Screenshot 2024-08-12 at 5.37.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/3825971b-36a9-4dae-baf2-19448c8d0f0f.png)

![Screenshot 2024-08-12 at 5.37.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/778349e5-9eec-4000-aca4-e70fca9a6d92.png)

![Screenshot 2024-08-12 at 5.39.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/97fe47e2-a35b-4d81-ac24-a9b91ea5bf77.png)

![Screenshot 2024-08-12 at 5.39.20 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/7e4418ef-907f-4ece-95d9-77dd10134fe4.png)

- HTML example:
![Screenshot 2024-08-12 at 5.41.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/ea3dc691-9c87-43e8-9ee5-1233ceec6f25.png)
