### PR TITLE
adding first pass tlv encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@changesets/cli": "^2.26.1",
     "@manypkg/cli": "^0.21.0",
+    "bech32": "^2.0.0",
     "ts-prune": "^0.10.3",
     "turbo": "v1.10.1",
     "unimported": "^1.29.2"

--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -4,6 +4,11 @@ import { KycStatus } from "./KycStatus.js";
 import { bech32m } from "bech32";
 import { TLVCodable, convertToBytes, mergeByteArrays } from "../tlvUtils.js"
 
+type TLVField = {
+    tag : number,
+    type: string
+}
+
 export class InvoiceCurrency implements TLVCodable {
     tlvMembers = new Map([
         ["code", 0],
@@ -11,7 +16,32 @@ export class InvoiceCurrency implements TLVCodable {
         ["symbol", 2],
         ["decimals", 3],
     ])
-        
+
+    tlvMembers2 = new Map<String, TLVField>([
+        ["code", {
+            tag : 0,
+            type : "string"
+        }],
+        ["name", {
+            tag : 1,
+            type : "string"
+        }],
+        ["symbol", {
+            tag : 2,
+            type : "string"
+        }],
+        ["decimals", {
+            tag : 3,
+            type : "number"
+        }],
+    ])
+
+    reverseTlVMembers = new Map([
+        [0, "code"],
+        [1, "name"],
+        [2, "symbol"],
+        [3, "decimals"]
+    ])
 
     constructor(
         // code is the ISO 4217 (if applicable) currency code (eg. "USD"). For cryptocurrencies, this will  be a ticker
@@ -28,24 +58,157 @@ export class InvoiceCurrency implements TLVCodable {
         public readonly decimals: number
     ) {}
 
-    toTLV(): Uint8Array {
-        const tlv = new Array<Uint8Array>();
-        Object.keys(this).forEach(key => {
-            if (this.tlvMembers.has(key)) {
-                let convert = convertToBytes(this[key as keyof InvoiceCurrency])
-                let len = convert.length;
-                const subArray = new Uint8Array();
-                subArray[0] = this.tlvMembers.get(key) as number;
-                subArray[1] = len;
-                tlv.push(mergeByteArrays([subArray, convert]));
-            } 
-        })
-        return mergeByteArrays(tlv);
+    toBech32String(): string { 
+        const bech32Str = bech32m.toWords(this.toTLV());
+        return bech32m.encode("uma", bech32Str);
     }
 
-    fromTLV(): void {
-        
+    fromBech32String(bvalue: string): number[] {
+        const decoded = bech32m.decode(bvalue)
+        return bech32m.fromWords(decoded.words);
+    }
+
+    // toTLV(): Uint8Array {
+    //     const tlv = new Array<Uint8Array>();
+    //     Object.keys(this).forEach(key => {
+    //         if (this.tlvMembers.has(key)) {
+    //             let convert = convertToBytes(this[key as keyof InvoiceCurrency])
+    //             let len = convert.length;
+    //             const subArray = new Uint8Array();
+    //             subArray[0] = this.tlvMembers.get(key) as number;
+    //             subArray[1] = len;
+    //             tlv.push(mergeByteArrays([subArray, convert]));
+    //         } 
+    //     })
+    //     return mergeByteArrays(tlv);
+    // }
+
+    toTLV(): Uint8Array {
+        const tlv = new ArrayBuffer(256);
+        let offset = 0;
+        const view = new DataView(tlv);
+        Object.keys(this).forEach(key => {
+            if (this.tlvMembers.has(key)) {
+                let convert = this.convertToBytes(this[key as keyof InvoiceCurrency], this.tlvMembers2.get(key)?.type ?? "");
+                let len = convert.length;
+                view.setUint8(offset++, this.tlvMembers.get(key) as number);
+                view.setUint8(offset++, len);
+                for (let i = 0; i<convert.length; i++) {
+                    view.setUint8(offset++, convert[i]);
+                }
+            } 
+        })
+        return new Uint8Array(tlv).slice(0, offset);
+    }
+
+    fromTLV2(tlvBytes: Uint8Array) {
+        console.log(`Inbound TLV : ${tlvBytes}`);
+        let offset = 0;
+        while (offset < tlvBytes.length) {
+            const tag = tlvBytes[offset++];
+            // console.log(`has reverse tag? ${tag}, ${typeof tag} ${this.reverseTlVMembers.has(tag)}`);
+            if (this.reverseTlVMembers.has(tag)) {
+                let reverseTag = this.reverseTlVMembers.get(tag) ?? "";
+                let len = tlvBytes[offset++];
+                let value = tlvBytes.slice(offset, offset+len);
+                let decodedValue = this.decodeFromBytes(value, this.tlvMembers2.get(reverseTag)?.type ?? "" )
+                console.log(`data: ${ tlvBytes.slice(offset, offset+len)}, ${decodedValue}`);
+                offset+= len;
+            }
+        }
     } 
+
+    decodeFromBytes(value: Uint8Array, valueType: string): any {
+        let result;
+        switch(valueType) {
+            case "number" : {
+                result = value[0]
+                break;
+            }
+            case "string" : {
+                result = new TextDecoder().decode(value);
+                break;
+            }
+            case "boolean" : {
+                result = value[0] === 1;
+                break;
+            }
+            case "byte_codable" : {
+                break;
+            }
+            case "tlv" : {
+
+                break;
+            }
+            case "byte_array": {
+                result = value;
+                break;
+            }
+            default: {
+                break;
+            }
+            
+        }
+        return result;
+    }
+
+    convertToBytes(value: any, valueType: string): Uint8Array {
+        let result = new Uint8Array();
+    switch(valueType) {
+        case "number" : {
+            let valueAsNumber = value as number;
+            if (Number.isInteger(valueAsNumber)) {
+                if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
+                    const buffer = new ArrayBuffer(1);
+                    const view = new DataView(buffer);
+                    view.setUint8(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
+                    const buffer = new ArrayBuffer(2);
+                    const view = new DataView(buffer);
+                    view.setUint16(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
+                    const buffer = new ArrayBuffer(4);
+                    const view = new DataView(buffer);
+                    view.setUint32(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                }
+            } else {
+                const buffer = new ArrayBuffer(4);
+                const view = new DataView(buffer);
+                view.setFloat32(0, valueAsNumber);
+                result = new Uint8Array(buffer);
+            }
+            break;
+        }
+        case "string" : {
+            const te = new TextEncoder();
+            result = te.encode(value);
+            break;
+        }
+        case "boolean" : {
+            result[0] = value as boolean === true ? 1 : 0
+            break;
+        }
+        case "tlv": {
+            let valueAsTLV = value as TLVCodable;
+            result = valueAsTLV.toTLV();
+            break;
+        }
+        case "byte_codable": {
+            break;
+        }
+        case "byte_array": {
+            result = value;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+    return result;
+    }
 }
 
 export class Invoice implements TLVCodable {
@@ -65,6 +228,44 @@ export class Invoice implements TLVCodable {
         ["callback",  12],
         ["signature",  10]
     ]);
+
+    tlvMembers2 = new Map<String, TLVField>([
+        ["receiverUma",  {
+            tag: 0, type: "string"
+        }],
+        ["invoiceUUID",  {
+            tag: 1, type: "string"
+        }],
+        ["amount",  {tag: 2, type: "number"}],
+        ["receivingCurrency",  {tag:3, type: "tlv"}],
+        ["expiration",  {tag:4, type: "number"}],
+        ["isSubectToTravelRule",  {tag:5, type:"boolean"}],
+        ["requiredPayerData",  {tag:6, type: "byte_codable:"}],
+        ["umaVersion",  {tag:7, type: "string"}],
+        ["commentCharsAllowed",  {tag:8, type:"number"}],
+        ["senderUma",  {tag:9, type: "string"}],
+        ["invoiceLimit",  {tag:10, type:"number"}],
+        ["kycStatus",  {tag:11, type: "byte_codable"}],
+        ["callback",  {tag:12, type:"string"}],
+        ["signature",  {tag:100, type:"byte_array"}]
+    ])
+
+    reverseTlVMembers = new Map([
+        [0, "receiverUma"],
+        [1, "invoiceUUID"],
+        [2, "amount"],
+        [3, "receivingCurrency"],
+        [4, "expiration"],
+        [5, "isSubjectToTravelRule"],
+        [6, "requiredPayerData"],
+        [7, "umaVersion"],
+        [8, "commentCharsAllowed"],
+        [9, "senderUma"],
+        [10, "invoiceLimit"],
+        [11, "kycStatus"],
+        [12, "callback"],
+        [100, "signature"],
+    ])
 
     constructor(
         // Receiving UMA address
@@ -117,7 +318,7 @@ export class Invoice implements TLVCodable {
             if (this.tlvMembers.has(key)) {
                 let convert = convertToBytes(this[key as keyof Invoice])
                 let len = convert.length;
-                const subArray = new Uint8Array();
+                const subArray = new Uint8Array(2);
                 subArray[0] = this.tlvMembers.get(key) ?? 0;
                 subArray[1] = len;
                 tlv.push(mergeByteArrays([subArray, convert]));
@@ -129,6 +330,133 @@ export class Invoice implements TLVCodable {
     toBech32String(): string { 
         const bech32Str = bech32m.toWords(this.toTLV())
         return bech32m.encode("uma", bech32Str);
+    }
+
+    toTLV2(): Uint8Array {
+        const tlv = new ArrayBuffer(256);
+        let offset = 0;
+        const view = new DataView(tlv);
+        Object.keys(this).forEach(key => {
+            if (this.tlvMembers.has(key)) {
+                let convert = this.convertToBytes(this[key as keyof Invoice], this.tlvMembers2.get(key)?.type ?? "");
+                let len = convert.length;
+                view.setUint8(offset++, this.tlvMembers.get(key) as number);
+                view.setUint8(offset++, len);
+                for (let i = 0; i<convert.length; i++) {
+                    view.setUint8(offset++, convert[i]);
+                }
+            } 
+        })
+        return new Uint8Array(tlv).slice(0, offset);
+    }
+
+    fromTLV2(tlvBytes: Uint8Array) {
+        console.log(`Inbound TLV : ${tlvBytes}`);
+        let offset = 0;
+        while (offset < tlvBytes.length) {
+            const tag = tlvBytes[offset++];
+            // console.log(`has reverse tag? ${tag}, ${typeof tag} ${this.reverseTlVMembers.has(tag)}`);
+            if (this.reverseTlVMembers.has(tag)) {
+                let reverseTag = this.reverseTlVMembers.get(tag) ?? "";
+                let len = tlvBytes[offset++];
+                let value = tlvBytes.slice(offset, offset+len);
+                let decodedValue = this.decodeFromBytes(value, this.tlvMembers2.get(reverseTag)?.type ?? "" )
+                console.log(`data: ${ tlvBytes.slice(offset, offset+len)}, ${decodedValue}`);
+                offset+= len;
+            }
+        }
+    } 
+
+    decodeFromBytes(value: Uint8Array, valueType: string): any {
+        let result;
+        switch(valueType) {
+            case "number" : {
+                result = value[0]
+                break;
+            }
+            case "string" : {
+                result = new TextDecoder().decode(value);
+                break;
+            }
+            case "boolean" : {
+                result = value[0] === 1;
+                break;
+            }
+            case "byte_codable" : {
+                break;
+            }
+            case "tlv" : {
+
+                break;
+            }
+            case "byte_array": {
+                result = value;
+                break;
+            }
+            default: {
+                break;
+            }
+            
+        }
+        return result;
+    }
+
+    convertToBytes(value: any, valueType: string): Uint8Array {
+        let result = new Uint8Array();
+    switch(valueType) {
+        case "number" : {
+            let valueAsNumber = value as number;
+            if (Number.isInteger(valueAsNumber)) {
+                if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
+                    const buffer = new ArrayBuffer(1);
+                    const view = new DataView(buffer);
+                    view.setUint8(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
+                    const buffer = new ArrayBuffer(2);
+                    const view = new DataView(buffer);
+                    view.setUint16(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
+                    const buffer = new ArrayBuffer(4);
+                    const view = new DataView(buffer);
+                    view.setUint32(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
+                }
+            } else {
+                const buffer = new ArrayBuffer(4);
+                const view = new DataView(buffer);
+                view.setFloat32(0, valueAsNumber);
+                result = new Uint8Array(buffer);
+            }
+            break;
+        }
+        case "string" : {
+            const te = new TextEncoder();
+            result = te.encode(value);
+            break;
+        }
+        case "boolean" : {
+            result[0] = value as boolean === true ? 1 : 0
+            break;
+        }
+        case "tlv": {
+            let valueAsTLV = value as TLVCodable;
+            result = valueAsTLV.toTLV();
+            break;
+        }
+        case "byte_codable": {
+            break;
+        }
+        case "byte_array": {
+            result = value;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+    return result;
     }
 }
 

--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -1,26 +1,68 @@
-import { CounterPartyDataOptions } from "./CounterPartyData.js";
-import { KycStatus } from "./KycStatus.js";
+import { CounterPartyDataOption, CounterPartyDataOptions, CounterPartyDataOptionSchema } from "./CounterPartyData.js";
+import { KycStatus, kycStatusToString } from "./KycStatus.js";
 import { bech32m } from "bech32";
-import { TLVCodable, convertToBytes, decodeFromBytes } from "../tlvUtils.js"
+import { ByteCodable, TLVCodable, convertToBytes, decodeFromBytes } from "../tlvUtils.js"
+import { z } from "zod";
+import { optionalIgnoringNull } from "../zodUtils.js";
+
+export class InvoiceKycStatus implements ByteCodable {
+    constructor(
+        public readonly status: KycStatus
+    ) { }
+
+    toBytes(): Uint8Array {
+        return new TextEncoder().encode(kycStatusToString(this.status));
+    }
+}
+
+export class InvoiceCounterPartyDataOptions implements ByteCodable {
+    constructor(
+        public readonly options: CounterPartyDataOptions
+    ) { }
+
+    toBytes(): Uint8Array {
+        let formatArray = new Array<string>();
+        for (const key in this.options) {
+            let k = key as keyof CounterPartyDataOptions;
+            formatArray.push(`${key}:${this.options[k].mandatory ? "1" : "0"}`);
+        }
+        let formatStr = formatArray.join(",");
+        return new TextEncoder().encode(formatStr);
+    }
+
+    static fromBytes(bytes: Uint8Array): CounterPartyDataOptions {
+        let result: CounterPartyDataOptions = {};
+        let options = new TextDecoder().decode(bytes);
+        options.split(",").forEach((dataOption) => {
+            let dataOptionsSplit = dataOption.split(":");
+            if (dataOptionsSplit.length == 2) {
+                result[dataOptionsSplit[0]] = {
+                    mandatory: dataOptionsSplit[1] === "1"
+                }
+            }
+        });
+        return result;
+    }
+}
 
 export class InvoiceCurrency implements TLVCodable {
 
     tlvMembers = new Map([
         ["code", {
-            tag : 0,
-            type : "string"
+            tag: 0,
+            type: "string"
         }],
         ["name", {
-            tag : 1,
-            type : "string"
+            tag: 1,
+            type: "string"
         }],
         ["symbol", {
-            tag : 2,
-            type : "string"
+            tag: 2,
+            type: "string"
         }],
         ["decimals", {
-            tag : 3,
-            type : "number"
+            tag: 3,
+            type: "number"
         }],
     ])
 
@@ -44,76 +86,73 @@ export class InvoiceCurrency implements TLVCodable {
 
         // The number of digits after the decimal point for display on the sender side
         public readonly decimals: number
-    ) {}
-
-    toBech32String(): string { 
-        const bech32Str = bech32m.toWords(this.toTLV());
-        return bech32m.encode("uma", bech32Str);
-    }
-
-    fromBech32String(bvalue: string): number[] {
-        const decoded = bech32m.decode(bvalue)
-        return bech32m.fromWords(decoded.words);
-    }
+    ) { }
 
     toTLV(): Uint8Array {
         const tlv = new ArrayBuffer(256);
         let offset = 0;
         const view = new DataView(tlv);
         Object.keys(this).forEach(key => {
-            if (this.tlvMembers.has(key)) {
-                let convert = convertToBytes(this[key as keyof InvoiceCurrency], this.tlvMembers.get(key)?.type ?? "");
-                let len = convert.length;
-                view.setUint8(offset++, this.tlvMembers.get(key)?.tag as number);
-                view.setUint8(offset++, len);
-                for (let i = 0; i<convert.length; i++) {
+            if (this[key as keyof InvoiceCurrency] !== undefined && this.tlvMembers.get(key) !== undefined) {
+                const { tag, type } = this.tlvMembers.get(key)!!;
+                let convert = convertToBytes(this[key as keyof InvoiceCurrency], type);
+                let byteLength = convert.length;
+                view.setUint8(offset++, tag as number);
+                view.setUint8(offset++, byteLength);
+                for (let i = 0; i < convert.length; i++) {
                     view.setUint8(offset++, convert[i]);
                 }
-            } 
+            }
         })
         return new Uint8Array(tlv).slice(0, offset);
     }
 
-    fromTLV(tlvBytes: Uint8Array) {
-        console.log(`Inbound TLV : ${tlvBytes}`);
+    fromTLV(tlvBytes: Uint8Array): InvoiceCurrency {
         let offset = 0;
+        let result: any = {};
         while (offset < tlvBytes.length) {
             const tag = tlvBytes[offset++];
-            // console.log(`has reverse tag? ${tag}, ${typeof tag} ${this.reverseTlVMembers.has(tag)}`);
             if (this.reverseTlVMembers.has(tag)) {
                 let reverseTag = this.reverseTlVMembers.get(tag) ?? "";
                 let len = tlvBytes[offset++];
-                let value = tlvBytes.slice(offset, offset+len);
-                let decodedValue = decodeFromBytes(value, this.tlvMembers.get(reverseTag)?.type ?? "" )
-                console.log(`data: ${ tlvBytes.slice(offset, offset+len)}, ${decodedValue}`);
-                offset+= len;
+                let value = tlvBytes.slice(offset, offset + len);
+                result[reverseTag] = decodeFromBytes(value, this.tlvMembers.get(reverseTag)?.type ?? "", len)
+                offset += len;
             }
         }
-    } 
+        let validated: z.infer<typeof InvoiceCurrencySchema>;
+        try {
+            validated = InvoiceCurrencySchema.parse(result);
+        } catch (e) {
+            throw new Error("invalid invoice currency response", { cause: e });
+        }
+        return new InvoiceCurrency(
+            validated.code, validated.name, validated.symbol, validated.decimals
+        )
+    }
 
 }
 
 export class Invoice implements TLVCodable {
-
     tlvMembers = new Map([
-        ["receiverUma",  {
+        ["receiverUma", {
             tag: 0, type: "string"
         }],
-        ["invoiceUUID",  {
+        ["invoiceUUID", {
             tag: 1, type: "string"
         }],
-        ["amount",  {tag: 2, type: "number"}],
-        ["receivingCurrency",  {tag:3, type: "tlv"}],
-        ["expiration",  {tag:4, type: "number"}],
-        ["isSubectToTravelRule",  {tag:5, type:"boolean"}],
-        ["requiredPayerData",  {tag:6, type: "byte_codable:"}],
-        ["umaVersion",  {tag:7, type: "string"}],
-        ["commentCharsAllowed",  {tag:8, type:"number"}],
-        ["senderUma",  {tag:9, type: "string"}],
-        ["invoiceLimit",  {tag:10, type:"number"}],
-        ["kycStatus",  {tag:11, type: "byte_codable"}],
-        ["callback",  {tag:12, type:"string"}],
-        ["signature",  {tag:100, type:"byte_array"}]
+        ["amount", { tag: 2, type: "number" }],
+        ["receivingCurrency", { tag: 3, type: "tlv" }],
+        ["expiration", { tag: 4, type: "number" }],
+        ["isSubectToTravelRule", { tag: 5, type: "boolean" }],
+        ["requiredPayerData", { tag: 6, type: "byte_codeable" }],
+        ["umaVersion", { tag: 7, type: "string" }],
+        ["commentCharsAllowed", { tag: 8, type: "number" }],
+        ["senderUma", { tag: 9, type: "string" }],
+        ["invoiceLimit", { tag: 10, type: "number" }],
+        ["kycStatus", { tag: 11, type: "byte_codeable" }],
+        ["callback", { tag: 12, type: "string" }],
+        ["signature", { tag: 100, type: "byte_array" }]
     ])
 
     reverseTlVMembers = new Map([
@@ -139,7 +178,7 @@ export class Invoice implements TLVCodable {
 
         // Invoice UUID Served as both the identifier of the UMA invoice, and the validation of proof of payment.
         public readonly invoiceUUID: string,
-        
+
         // The amount of invoice to be paid in the smalest unit of the ReceivingCurrency.
         public readonly amount: number,
 
@@ -151,39 +190,39 @@ export class Invoice implements TLVCodable {
 
         // Indicates whether the VASP is a financial institution that requires travel rule information.
         public readonly isSubectToTravelRule: boolean,
-        
+
         // RequiredPayerData the data about the payer that the sending VASP must provide in order to send a payment.    
-        // public readonly requiredPayerData: CounterPartyDataOptions | undefined, 
-        
+        public readonly requiredPayerData: InvoiceCounterPartyDataOptions | undefined,
+
         // UmaVersion is a list of UMA versions that the VASP supports for this transaction. It should be
-	    // containing the lowest minor version of each major version it supported, separated by commas.    
+        // containing the lowest minor version of each major version it supported, separated by commas.    
         public readonly umaVersion: string,
-        
+
         // CommentCharsAllowed is the number of characters that the sender can include in the comment field of the pay request.    
         public readonly commentCharsAllowed: number | undefined,
 
         // The sender's UMA address. If this field presents, the UMA invoice should directly go to the sending VASP instead of showing in other formats.
         public readonly senderUma: string | undefined,
-        
+
         // The maximum number of the invoice can be paid
         public readonly invoiceLimit: number | undefined,
 
         // KYC status of the receiver, default is verified.
-        // public readonly kycStatus: KycStatus | undefined,
+        public readonly kycStatus: InvoiceKycStatus | undefined,
 
         // The callback url that the sender should send the PayRequest to.    
         public readonly callback: string,
 
         // The signature of the UMA invoice
-        public readonly signature: Uint8Array
-    ) {}
+        public readonly signature: Uint8Array | undefined
+    ) { }
 
-    toBech32String(): string { 
+    toBech32String(): string {
         const bech32Str = bech32m.toWords(this.toTLV())
         return bech32m.encode("uma", bech32Str, 256);
     }
 
-    fromBech32String(bvalue: string): number[] {
+    static fromBech32String(bvalue: string): number[] {
         const decoded = bech32m.decode(bvalue, 256);
         return bech32m.fromWords(decoded.words);
     }
@@ -194,30 +233,91 @@ export class Invoice implements TLVCodable {
         const view = new DataView(tlv);
         Object.keys(this).forEach(key => {
             if (this.tlvMembers.has(key)) {
-                const {tag, type} = this.tlvMembers.get(key)!!;
-                let convert = convertToBytes(this[key as keyof Invoice], type);
-                let len = convert.length;
-                view.setUint8(offset++, tag as number);
-                view.setUint8(offset++, len);
-                for (let i = 0; i<convert.length; i++) {
-                    view.setUint8(offset++, convert[i]);
+                if (this[key as keyof Invoice] !== undefined && this.tlvMembers.get(key) !== undefined) {
+                    const { tag, type } = this.tlvMembers.get(key)!!;
+                    let convert = convertToBytes(this[key as keyof Invoice], type);
+                    let byteLength = convert.length;
+                    view.setUint8(offset++, tag as number);
+                    view.setUint8(offset++, byteLength);
+                    for (let i = 0; i < convert.length; i++) {
+                        view.setUint8(offset++, convert[i]);
+                    }
                 }
-            } 
+            }
         })
         return new Uint8Array(tlv).slice(0, offset);
     }
 
     fromTLV(tlvBytes: Uint8Array) {
         let offset = 0;
+        let result: any = {};
         while (offset < tlvBytes.length) {
             const tag = tlvBytes[offset++];
             if (this.reverseTlVMembers.has(tag)) {
                 let reverseTag = this.reverseTlVMembers.get(tag)!!;
                 let len = tlvBytes[offset++];
-                let value = tlvBytes.slice(offset, offset+len);
-                let decodedValue = decodeFromBytes(value, this.tlvMembers.get(reverseTag)?.type ?? "" )
-                offset+= len;
+                let value = tlvBytes.slice(offset, offset + len);
+                result[reverseTag] = decodeFromBytes(
+                    value,
+                    this.tlvMembers.get(reverseTag)?.type ?? "",
+                    len
+                )
+                offset += len;
             }
         }
-    } 
+        let validated: z.infer<typeof InvoiceSchema>;
+        try {
+            validated = InvoiceSchema.parse(result);
+        } catch (e) {
+            throw new Error("invalid invoice response", { cause: e });
+        }
+        // return new Invoice(
+        //     validated.receiverUma,
+        //     validated.invoiceUUID,
+        //     validated.amount,
+        //     validated.receivingCurrency,
+        //     validated.expiration,
+        //     validated.isSubjectToTravelRule,
+        //     validated.requiredPayerData,
+        //     validated.umaVersion,
+        //     validated.commentCharsAllowed,
+        //     validated.senderUma,
+        //     validated.invoiceLimit,
+        //     validated.kycStatus,
+        //     validated.callback,
+        //     new Uint8Array(1)
+        // );
+    }
 }
+
+/**
+ * deserialize plan - create an "any" object with all of the fields. validate it
+ * then use this object to construct an invoice
+ */
+const InvoiceCurrencySchema = z.object({
+    code: z.string(),
+    name: z.string(),
+    symbol: z.string(),
+    decimals: z.number()
+});
+
+export const InvoiceSchema = z.object({
+    receiverUma: z.string(),
+    invoiceUUID: z.string(),
+    amount: z.number(),
+    receivingCurrency: InvoiceCurrencySchema,
+    expiration: z.number(),
+    isSubjectToTravelRule: z.boolean(),
+    requiredPayerData: optionalIgnoringNull(CounterPartyDataOptionSchema),
+    umaVersion: z.string(),
+    commentCharsAllowed: optionalIgnoringNull(z.number()),
+    senderUma: optionalIgnoringNull(z.string()),
+    invoiceLimit: optionalIgnoringNull(z.number()),
+    kycStatus: optionalIgnoringNull(z.nativeEnum(KycStatus)),
+    callback: z.string(),
+    signature: optionalIgnoringNull(z.instanceof(Uint8Array))
+});
+
+export type InvoiceParameters = z.infer<
+    typeof InvoiceSchema
+>;

--- a/packages/core/src/protocol/KycStatus.ts
+++ b/packages/core/src/protocol/KycStatus.ts
@@ -5,6 +5,14 @@ export enum KycStatus {
   Verified = "VERIFIED",
 }
 
+export function kycStatustoBytes(k: KycStatus): Uint8Array {
+  return new TextEncoder().encode(kycStatusToString(k));
+}
+
+export function kycStatusFromBytes(bytes: Uint8Array): KycStatus {
+  return kycStatusFromString(new TextDecoder().decode(bytes));
+}
+
 export function kycStatusFromString(s: string): KycStatus {
   switch (s) {
     default:

--- a/packages/core/src/protocol/KycStatus.ts
+++ b/packages/core/src/protocol/KycStatus.ts
@@ -5,14 +5,6 @@ export enum KycStatus {
   Verified = "VERIFIED",
 }
 
-export function kycStatustoBytes(k: KycStatus): Uint8Array {
-  return new TextEncoder().encode(kycStatusToString(k));
-}
-
-export function kycStatusFromBytes(bytes: Uint8Array): KycStatus {
-  return kycStatusFromString(new TextDecoder().decode(bytes));
-}
-
 export function kycStatusFromString(s: string): KycStatus {
   switch (s) {
     default:

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -755,7 +755,6 @@ describe("uma", () => {
   });
 
   it ("should properly encode/decode InvoiceCurrency", async () => {
-    expect(true).toEqual(true);
     const invoiceCurrency = new InvoiceCurrency("USD","US Dollar","$",2);
     let tlvBytes = invoiceCurrency.toTLV()
     let decodedInvoiceCurrency = invoiceCurrency.fromTLV(tlvBytes)
@@ -767,6 +766,7 @@ describe("uma", () => {
 
   it("it should properly encode/decode Invoices", async () => {
     expect(true).toEqual(true);
+
     const dummyInvoiceTLV = await createUmaInvoice(
       "$foo@bar.com",
       "c7c07fec-cf00-431c-916f-6c13fc4b69f9",
@@ -788,6 +788,7 @@ describe("uma", () => {
        "https://example.com/callback", new TextEncoder().encode("sigature")
       );
     const tlv = dummyInvoiceTLV.toTLV()
+    console.log(tlv);
     const tlvDecoded = dummyInvoiceTLV.fromTLV(tlv);
     console.log(tlvDecoded);
   })

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -17,6 +17,7 @@ import { PayRequest } from "../protocol/PayRequest.js";
 import { parsePostTransactionCallback } from "../protocol/PostTransactionCallback.js";
 import { PubKeyResponse } from "../protocol/PubKeyResponse.js";
 import {
+  createUmaInvoice,
   getLnurlpResponse,
   getPayReqResponse,
   getPayRequest,
@@ -34,6 +35,7 @@ import {
   verifyUmaLnurlpResponseSignature,
 } from "../uma.js";
 import { UmaProtocolVersion } from "../version.js";
+import { InvoiceCurrency } from "../protocol/Invoice.js";
 
 const generateKeypair = async () => {
   let privateKey: Uint8Array;
@@ -750,6 +752,23 @@ describe("uma", () => {
     ).toString();
     expect(decryptedTrInfo).toBe(trInfo);
   });
+
+  it("does some stuff with invoices", async () => {
+    expect(true).toEqual(true);
+    const invoice = await createUmaInvoice(
+      "$foo@bar.com",
+      "c7c07fec-cf00-431c-916f-6c13fc4b69f9",
+      1000,
+      new InvoiceCurrency("USD","US Dollar","$",2),
+      100000,
+      true,
+      "1.0", 10,
+      "sender_uma", 10,
+       "https://example.com/callback", new TextEncoder().encode("sigature")
+      );
+    const invoiceTLV = invoice.toTLV()
+    console.log(invoiceTLV);
+  })
 
   it("should serialize and deserialize pub key response", async () => {
     const keysOnlyResponse = {

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -755,7 +755,7 @@ describe("uma", () => {
 
   it("does some stuff with invoices", async () => {
     expect(true).toEqual(true);
-    const invoice = await createUmaInvoice(
+    const dummyInvoiceTLV = await createUmaInvoice(
       "$foo@bar.com",
       "c7c07fec-cf00-431c-916f-6c13fc4b69f9",
       1000,
@@ -766,8 +766,8 @@ describe("uma", () => {
       "sender_uma", 10,
        "https://example.com/callback", new TextEncoder().encode("sigature")
       );
-    const invoiceTLV = invoice.toTLV()
-    console.log(invoiceTLV);
+    console.log(`written tlv values are ${dummyInvoiceTLV.toTLV2()}`);
+    dummyInvoiceTLV.fromTLV2(dummyInvoiceTLV.toTLV2());
   })
 
   it("should serialize and deserialize pub key response", async () => {

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -35,7 +35,8 @@ import {
   verifyUmaLnurlpResponseSignature,
 } from "../uma.js";
 import { UmaProtocolVersion } from "../version.js";
-import { InvoiceCurrency } from "../protocol/Invoice.js";
+import { Invoice, InvoiceCurrency } from "../protocol/Invoice.js";
+import { bech32m } from "bech32";
 
 const generateKeypair = async () => {
   let privateKey: Uint8Array;
@@ -753,7 +754,18 @@ describe("uma", () => {
     expect(decryptedTrInfo).toBe(trInfo);
   });
 
-  it("does some stuff with invoices", async () => {
+  it ("should properly encode/decode InvoiceCurrency", async () => {
+    expect(true).toEqual(true);
+    const invoiceCurrency = new InvoiceCurrency("USD","US Dollar","$",2);
+    let tlvBytes = invoiceCurrency.toTLV()
+    let decodedInvoiceCurrency = invoiceCurrency.fromTLV(tlvBytes)
+    expect(decodedInvoiceCurrency.code).toBe("USD");
+    expect(decodedInvoiceCurrency.name).toBe("US Dollar");
+    expect(decodedInvoiceCurrency.symbol).toBe("$");
+    expect(decodedInvoiceCurrency.decimals).toBe(2);
+  })
+
+  it("it should properly encode/decode Invoices", async () => {
     expect(true).toEqual(true);
     const dummyInvoiceTLV = await createUmaInvoice(
       "$foo@bar.com",
@@ -762,16 +774,22 @@ describe("uma", () => {
       new InvoiceCurrency("USD","US Dollar","$",2),
       100000,
       true,
+      {
+        name: {
+          mandatory: false,
+        },
+        email: {
+          mandatory: false,
+        },
+      },
       "1.0", 10,
       "sender_uma", 10,
+      KycStatus.Pending,
        "https://example.com/callback", new TextEncoder().encode("sigature")
       );
     const tlv = dummyInvoiceTLV.toTLV()
-    console.log(`written tlv values are ${tlv}, length ${tlv.length}`);
-    const b32str = dummyInvoiceTLV.toBech32String();
-    console.log(`bech32 encoding ${b32str}`);
-    const b32strDecode = dummyInvoiceTLV.fromBech32String(b32str);
-    console.log(`decoded bech32 string is ${b32strDecode}, ${b32strDecode.length}`);
+    const tlvDecoded = dummyInvoiceTLV.fromTLV(tlv);
+    console.log(tlvDecoded);
   })
 
   it("should serialize and deserialize pub key response", async () => {

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -766,8 +766,12 @@ describe("uma", () => {
       "sender_uma", 10,
        "https://example.com/callback", new TextEncoder().encode("sigature")
       );
-    console.log(`written tlv values are ${dummyInvoiceTLV.toTLV2()}`);
-    dummyInvoiceTLV.fromTLV2(dummyInvoiceTLV.toTLV2());
+    const tlv = dummyInvoiceTLV.toTLV()
+    console.log(`written tlv values are ${tlv}, length ${tlv.length}`);
+    const b32str = dummyInvoiceTLV.toBech32String();
+    console.log(`bech32 encoding ${b32str}`);
+    const b32strDecode = dummyInvoiceTLV.fromBech32String(b32str);
+    console.log(`decoded bech32 string is ${b32strDecode}, ${b32strDecode.length}`);
   })
 
   it("should serialize and deserialize pub key response", async () => {

--- a/packages/core/src/tlvUtils.ts
+++ b/packages/core/src/tlvUtils.ts
@@ -24,21 +24,23 @@ export function convertToBytes(value: any, valueType: string): Uint8Array {
     switch (valueType) {
         case "number": {
             let valueAsNumber = value as number;
+            console.log(`number : ${valueAsNumber}`);
             if (Number.isInteger(valueAsNumber)) {
-                if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
+                if (valueAsNumber >= -128 && valueAsNumber <= 127) { // uint 8
                     const buffer = new ArrayBuffer(1);
                     const view = new DataView(buffer);
-                    view.setUint8(0, valueAsNumber);
+                    view.setInt8(0, valueAsNumber);
                     result = new Uint8Array(buffer);
-                } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
+                } else if (valueAsNumber >= -32768 && valueAsNumber <= 32767) { // uint 16
                     const buffer = new ArrayBuffer(2);
                     const view = new DataView(buffer);
-                    view.setUint16(0, valueAsNumber);
+                    view.setInt16(0, valueAsNumber);
                     result = new Uint8Array(buffer);
-                } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
+                    console.log(result);
+                } else if (valueAsNumber >= -2147483648 && valueAsNumber <= 2147483647) { // unint 32
                     const buffer = new ArrayBuffer(4);
                     const view = new DataView(buffer);
-                    view.setUint32(0, valueAsNumber);
+                    view.setInt32(0, valueAsNumber);
                     result = new Uint8Array(buffer);
                 }
             } else {
@@ -55,7 +57,7 @@ export function convertToBytes(value: any, valueType: string): Uint8Array {
             break;
         }
         case "boolean": {
-            result[0] = value as boolean === true ? 1 : 0
+            result = new Uint8Array([value as boolean === true ? 1 : 0]);
             break;
         }
         case "tlv": {
@@ -83,18 +85,22 @@ export function decodeFromBytes(value: Uint8Array, valueType: string, length: nu
     let result;
     switch (valueType) {
         case "number": {
+            const view = new DataView(value.buffer)
             switch(length) {
                 case 1 : {
-                    result = value[0]
+                    result = view.getInt8(0);
                     break;
                 }
                 case 2 : { // 16 bit
+                    result = view.getInt16(0);
                     break
                 }
                 case 4 : { // 32 bit
+                    result = view.getInt32(0);
                     break;
                 }
                 case 8 : { // 64 bit
+                    result = view.getBigInt64(0);
                     break;
                 }
                 default: break;

--- a/packages/core/src/tlvUtils.ts
+++ b/packages/core/src/tlvUtils.ts
@@ -8,21 +8,30 @@ export function convertToBytes(value: any): Uint8Array {
     let result = new Uint8Array();
     switch(true) {
         case typeof value === "number" : {
-            const buffer = new ArrayBuffer(16);
-            const view = new DataView(buffer);
             let valueAsNumber = value as number;
             if (Number.isInteger(valueAsNumber)) {
                 if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
+                    const buffer = new ArrayBuffer(1);
+                    const view = new DataView(buffer);
                     view.setUint8(0, valueAsNumber);
-                } else if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 16
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
+                    const buffer = new ArrayBuffer(2);
+                    const view = new DataView(buffer);
                     view.setUint16(0, valueAsNumber);
-                } else if (valueAsNumber >= -128 || valueAsNumber <= 127) { // unint 32
+                    result = new Uint8Array(buffer);
+                } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
+                    const buffer = new ArrayBuffer(4);
+                    const view = new DataView(buffer);
                     view.setUint32(0, valueAsNumber);
+                    result = new Uint8Array(buffer);
                 }
             } else {
+                const buffer = new ArrayBuffer(4);
+                const view = new DataView(buffer);
                 view.setFloat32(0, valueAsNumber);
+                result = new Uint8Array(buffer);
             }
-            result = new Uint8Array(buffer);
             break;
         }
         case typeof value === "string" : {

--- a/packages/core/src/tlvUtils.ts
+++ b/packages/core/src/tlvUtils.ts
@@ -1,61 +1,12 @@
 
 export interface TLVCodable {
-    tlvMembers: Map<string, number>
+    tlvMembers: Map<string, TLVField>
     toTLV(): Uint8Array
 }
 
-export function convertToBytes(value: any): Uint8Array {
-    let result = new Uint8Array();
-    switch(true) {
-        case typeof value === "number" : {
-            let valueAsNumber = value as number;
-            if (Number.isInteger(valueAsNumber)) {
-                if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
-                    const buffer = new ArrayBuffer(1);
-                    const view = new DataView(buffer);
-                    view.setUint8(0, valueAsNumber);
-                    result = new Uint8Array(buffer);
-                } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
-                    const buffer = new ArrayBuffer(2);
-                    const view = new DataView(buffer);
-                    view.setUint16(0, valueAsNumber);
-                    result = new Uint8Array(buffer);
-                } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
-                    const buffer = new ArrayBuffer(4);
-                    const view = new DataView(buffer);
-                    view.setUint32(0, valueAsNumber);
-                    result = new Uint8Array(buffer);
-                }
-            } else {
-                const buffer = new ArrayBuffer(4);
-                const view = new DataView(buffer);
-                view.setFloat32(0, valueAsNumber);
-                result = new Uint8Array(buffer);
-            }
-            break;
-        }
-        case typeof value === "string" : {
-            const te = new TextEncoder();
-            result = te.encode(value);
-            break;
-        }
-        case typeof value === "boolean" : {
-            result[0] = value as boolean === true ? 1 : 0
-            break;
-        }
-        case "toTLV" in value: {
-            let valueAsTLV = value as TLVCodable;
-            result = valueAsTLV.toTLV();
-            break;
-        }
-        case "toBytes" in value: {
-            break;
-        }
-        default: {
-            break;
-        }
-    }
-    return result;
+type TLVField = {
+    tag : number,
+    type: string
 }
 
 export function mergeByteArrays(byteArrays: Array<Uint8Array>): Uint8Array {
@@ -67,4 +18,96 @@ export function mergeByteArrays(byteArrays: Array<Uint8Array>): Uint8Array {
         offset+= array.length;
     }
     return combinedArray;
+}
+
+export function convertToBytes(value: any, valueType: string): Uint8Array {
+    let result = new Uint8Array();
+switch(valueType) {
+    case "number" : {
+        let valueAsNumber = value as number;
+        if (Number.isInteger(valueAsNumber)) {
+            if (valueAsNumber >= -128 || valueAsNumber <= 127) { // uint 8
+                const buffer = new ArrayBuffer(1);
+                const view = new DataView(buffer);
+                view.setUint8(0, valueAsNumber);
+                result = new Uint8Array(buffer);
+            } else if (valueAsNumber >= -32768 || valueAsNumber <= 32767) { // uint 16
+                const buffer = new ArrayBuffer(2);
+                const view = new DataView(buffer);
+                view.setUint16(0, valueAsNumber);
+                result = new Uint8Array(buffer);
+            } else if (valueAsNumber >= -2147483648 || valueAsNumber <= 2147483647) { // unint 32
+                const buffer = new ArrayBuffer(4);
+                const view = new DataView(buffer);
+                view.setUint32(0, valueAsNumber);
+                result = new Uint8Array(buffer);
+            }
+        } else {
+            const buffer = new ArrayBuffer(4);
+            const view = new DataView(buffer);
+            view.setFloat32(0, valueAsNumber);
+            result = new Uint8Array(buffer);
+        }
+        break;
+    }
+    case "string" : {
+        const te = new TextEncoder();
+        result = te.encode(value);
+        break;
+    }
+    case "boolean" : {
+        result[0] = value as boolean === true ? 1 : 0
+        break;
+    }
+    case "tlv": {
+        let valueAsTLV = value as TLVCodable;
+        result = valueAsTLV.toTLV();
+        break;
+    }
+    case "byte_codable": {
+        break;
+    }
+    case "byte_array": {
+        result = value;
+        break;
+    }
+    default: {
+        break;
+    }
+}
+return result;
+}
+
+export function decodeFromBytes(value: Uint8Array, valueType: string): any {
+    let result;
+    switch(valueType) {
+        case "number" : {
+            result = value[0]
+            break;
+        }
+        case "string" : {
+            result = new TextDecoder().decode(value);
+            break;
+        }
+        case "boolean" : {
+            result = value[0] === 1;
+            break;
+        }
+        case "byte_codable" : {
+            break;
+        }
+        case "tlv" : {
+
+            break;
+        }
+        case "byte_array": {
+            result = value;
+            break;
+        }
+        default: {
+            break;
+        }
+        
+    }
+    return result;
 }

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -41,7 +41,7 @@ import {
   UmaProtocolVersion,
   UnsupportedVersionError,
 } from "./version.js";
-import { Invoice, InvoiceCurrency } from "./protocol/Invoice.js";
+import { Invoice, InvoiceCounterPartyDataOptions, InvoiceCurrency, InvoiceKycStatus } from "./protocol/Invoice.js";
 
 export const createSha256Hash = async (
   data: Uint8Array,
@@ -1047,12 +1047,12 @@ export async function createUmaInvoice(
     receivingCurrency: InvoiceCurrency,
     expiration: number,
     isSubectToTravelRule: boolean,
-    // requiredPayerData: CounterPartyDataOptions | undefined, 
+    requiredPayerData: CounterPartyDataOptions | undefined, 
     umaVersion: string,
     commentCharsAllowed: number | undefined,
     senderUma: string | undefined,
     invoiceLimit: number | undefined,
-    // kycStatus: KycStatus | undefined,    
+    kycStatus: KycStatus | undefined,    
     callback: string,
     signature: Uint8Array
 ): Promise<Invoice> {
@@ -1063,12 +1063,12 @@ export async function createUmaInvoice(
     receivingCurrency,
     expiration,
     isSubectToTravelRule,
-    // requiredPayerData, 
+    requiredPayerData ? new InvoiceCounterPartyDataOptions(requiredPayerData) : undefined, 
     umaVersion,
     commentCharsAllowed,
     senderUma,
     invoiceLimit,
-    // kycStatus,
+    kycStatus ? new InvoiceKycStatus(kycStatus) : undefined,
     callback,
     signature
   )

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -41,7 +41,7 @@ import {
   UmaProtocolVersion,
   UnsupportedVersionError,
 } from "./version.js";
-import { Invoice } from "protocol/Invoice.js";
+import { Invoice, InvoiceCurrency } from "./protocol/Invoice.js";
 
 export const createSha256Hash = async (
   data: Uint8Array,
@@ -1044,15 +1044,15 @@ export async function createUmaInvoice(
     receiverUma: string,
     invoiceUUID: string,
     amount: number,
-    receivingCurrency: Currency,
+    receivingCurrency: InvoiceCurrency,
     expiration: number,
     isSubectToTravelRule: boolean,
-    requiredPayerData: CounterPartyDataOptions | undefined, 
-    umaVersion: String,
+    // requiredPayerData: CounterPartyDataOptions | undefined, 
+    umaVersion: string,
     commentCharsAllowed: number | undefined,
     senderUma: string | undefined,
     invoiceLimit: number | undefined,
-    kycStatus: KycStatus | undefined,    
+    // kycStatus: KycStatus | undefined,    
     callback: string,
     signature: Uint8Array
 ): Promise<Invoice> {
@@ -1063,12 +1063,12 @@ export async function createUmaInvoice(
     receivingCurrency,
     expiration,
     isSubectToTravelRule,
-    requiredPayerData, 
+    // requiredPayerData, 
     umaVersion,
     commentCharsAllowed,
     senderUma,
     invoiceLimit,
-    kycStatus,    
+    // kycStatus,
     callback,
     signature
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2275,6 +2275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: fa15acb270b59aa496734a01f9155677b478987b773bf701f465858bf1606c6a970085babd43d71ce61895f1baa594cb41a2cd1394bd2c6698f03cc2d811300e
+  languageName: node
+  linkType: hard
+
 "better-path-resolve@npm:1.0.0":
   version: 1.0.0
   resolution: "better-path-resolve@npm:1.0.0"
@@ -7670,6 +7677,7 @@ __metadata:
   dependencies:
     "@changesets/cli": ^2.26.1
     "@manypkg/cli": ^0.21.0
+    bech32: ^2.0.0
     ts-prune: ^0.10.3
     turbo: v1.10.1
     unimported: ^1.29.2


### PR DESCRIPTION
Create UMA Invoice in TS

this PR creates a schema representing Invoice and a Serializer which can convert Invoices to TLV format and Bech32 string

This implementation leverages Zod to define schemas and validate them upon deserialization

PR 1 is the first attempt at Invoice - typescript doesn't have great type introspection at runtime so this attempt is closer to what I'd do for something like kotlin, but ultimately didn't work out