### PR TITLE
Load manrope font outside of shadow dom

### DIFF
--- a/packages/uma-auth-client/src/utils/defineWebComponent.tsx
+++ b/packages/uma-auth-client/src/utils/defineWebComponent.tsx
@@ -1,8 +1,9 @@
 import createCache from "@emotion/cache";
-import { CacheProvider } from "@emotion/react";
-import { LightsparkProvider } from "@lightsparkdev/ui/components";
+import { CacheProvider, ThemeProvider } from "@emotion/react";
+import { themes } from "@lightsparkdev/ui/styles/themes";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { GlobalStyles } from "src/GlobalStyles";
 
 type ComponentWithShadowRoot = React.FC;
 
@@ -27,6 +28,17 @@ export default function defineWebComponent(
         emotionInsertionPoint.setAttribute("name", "emotion-insertion-point");
         this.shadowRoot?.appendChild(emotionInsertionPoint);
 
+        // Load Manrope font. Fonts can't be loaded in the shadow dom so we must load it outside.
+        const style = document.createElement("style");
+        const head =
+          document.head ||
+          (document.getElementsByTagName("head")[0] as HTMLHeadElement);
+        head.appendChild(style);
+        style.type = "text/css";
+        style.innerHTML = `
+          @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@200..800');
+        `;
+
         // Create emotion cache so dynamic styles get defined to the insertion node
         const cache = createCache({
           key: "uma-auth-client",
@@ -37,9 +49,10 @@ export default function defineWebComponent(
         const reactNode = (
           <React.StrictMode>
             <CacheProvider value={cache}>
-              <LightsparkProvider>
+              <ThemeProvider theme={themes.umaAuthSdkLight}>
+                <GlobalStyles />
                 <Component />
-              </LightsparkProvider>
+              </ThemeProvider>
             </CacheProvider>
           </React.StrictMode>
         );


### PR DESCRIPTION
Apparently fonts can't be loaded from inside a shadow dom, so this manually loads it outside instead.