### PR TITLE
need to fix number serialization - 64 bit ints, such as timestamps, were not serializing properly. also, increase buffer size for creating serialized invoices

### DIFF
--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -103,7 +103,7 @@ const TLVInvoiceCurrencySerializer = {
   },
 
   serialize(invoice: InvoiceCurrency): Uint8Array {
-    const tlv = new ArrayBuffer(256);
+    const tlv = new ArrayBuffer(512);
     let offset = 0;
     const view = new DataView(tlv);
     Object.keys(invoice).forEach((key) => {
@@ -194,7 +194,7 @@ export const InvoiceSerializer = {
   },
 
   toTLV(invoice: Invoice): Uint8Array {
-    const tlv = new ArrayBuffer(256);
+    const tlv = new ArrayBuffer(512);
     let offset = 0;
     const view = new DataView(tlv);
     Object.keys(invoice).forEach((key) => {

--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -217,11 +217,11 @@ export const InvoiceSerializer = {
     return new Uint8Array(tlv).slice(0, offset);
   },
 
-  toBech32(invoice: Invoice): string {
+  toBech32(invoice: Invoice, maxLength: number | undefined = undefined): string {
     return bech32.encode(
       UMA_BECH32_PREFIX,
       bech32m.toWords(this.toTLV(invoice)),
-      BECH_32_MAX_LENGTH,
+      maxLength ?? BECH_32_MAX_LENGTH,
     );
   },
 
@@ -252,8 +252,8 @@ export const InvoiceSerializer = {
     return validated;
   },
 
-  fromBech32(bech32str: string): Invoice {
-    const decoded = bech32.decode(bech32str, BECH_32_MAX_LENGTH);
+  fromBech32(bech32str: string, maxLength: number | undefined = undefined): Invoice {
+    const decoded = bech32.decode(bech32str, maxLength ?? BECH_32_MAX_LENGTH);
     return this.fromTLV(new Uint8Array(bech32m.fromWords(decoded.words)));
   },
 };

--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -21,7 +21,7 @@ import {
 } from "./KycStatus.js";
 
 const UMA_BECH32_PREFIX = "uma";
-const BECH_32_MAX_LENGTH = 512;
+const BECH_32_MAX_LENGTH = 1024;
 
 const InvoiceCurrencySchema = z.object({
   name: z.string(),

--- a/packages/core/src/protocol/Invoice.ts
+++ b/packages/core/src/protocol/Invoice.ts
@@ -217,7 +217,10 @@ export const InvoiceSerializer = {
     return new Uint8Array(tlv).slice(0, offset);
   },
 
-  toBech32(invoice: Invoice, maxLength: number | undefined = undefined): string {
+  toBech32(
+    invoice: Invoice,
+    maxLength: number | undefined = undefined,
+  ): string {
     return bech32.encode(
       UMA_BECH32_PREFIX,
       bech32m.toWords(this.toTLV(invoice)),
@@ -252,7 +255,10 @@ export const InvoiceSerializer = {
     return validated;
   },
 
-  fromBech32(bech32str: string, maxLength: number | undefined = undefined): Invoice {
+  fromBech32(
+    bech32str: string,
+    maxLength: number | undefined = undefined,
+  ): Invoice {
     const decoded = bech32.decode(bech32str, maxLength ?? BECH_32_MAX_LENGTH);
     return this.fromTLV(new Uint8Array(bech32m.fromWords(decoded.words)));
   },

--- a/packages/core/src/serializerUtils.ts
+++ b/packages/core/src/serializerUtils.ts
@@ -84,9 +84,9 @@ export function deserializeNumber(value: Uint8Array): number {
       break;
     }
     default: {
-        result = view.getInt8(0);
-        break;
-      }
+      result = view.getInt8(0);
+      break;
+    }
   }
   return result;
 }

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -849,7 +849,6 @@ describe("uma", () => {
             mandatory: true,
           },
         },
-        umaVersion: "0.3",
         senderUma: undefined,
         invoiceLimit: undefined,
         commentCharsAllowed: undefined,

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -1080,7 +1080,20 @@ export async function verifyPostTransactionCallbackSignature(
 }
 
 export async function createUmaInvoice(
-  options: {
+  {
+    receiverUma,
+    invoiceUUID,
+    amount,
+    receivingCurrency,
+    expiration,
+    isSubjectToTravelRule,
+    requiredPayerData,
+    commentCharsAllowed,
+    senderUma,
+    invoiceLimit,
+    kycStatus,
+    callback,
+  }: {
     receiverUma: string;
     invoiceUUID: string;
     amount: number;
@@ -1088,7 +1101,6 @@ export async function createUmaInvoice(
     expiration: number;
     isSubjectToTravelRule: boolean;
     requiredPayerData: CounterPartyDataOptions | undefined;
-    umaVersion: string;
     commentCharsAllowed: number | undefined;
     senderUma: string | undefined;
     invoiceLimit: number | undefined;
@@ -1097,7 +1109,21 @@ export async function createUmaInvoice(
   },
   privateKeyBytes: Uint8Array,
 ): Promise<Invoice> {
-  const invoice: Invoice = options;
+  const invoice: Invoice = {
+    receiverUma: receiverUma,
+    invoiceUUID: invoiceUUID,
+    amount: amount,
+    receivingCurrency: receivingCurrency,
+    expiration: expiration,
+    isSubjectToTravelRule: isSubjectToTravelRule,
+    requiredPayerData: requiredPayerData,
+    commentCharsAllowed: commentCharsAllowed,
+    senderUma: senderUma,
+    invoiceLimit: invoiceLimit,
+    kycStatus: kycStatus,
+    callback: callback,
+    umaVersion: UmaProtocolVersion,
+  };
   const invoicePayload = InvoiceSerializer.toTLV(invoice);
   const signature = await signBytePayload(invoicePayload, privateKeyBytes);
   invoice.signature = signature;


### PR DESCRIPTION
# Bug Fix

Serialization functions for numbers were broken in uma sdk for Invoice.
This PR updates the handling of 64 bit numbers which is essential for unix timestamps.

Additionally, increase the buffer size when serializing Invoices