### PR TITLE
Add invoice ID to PayReq, to track uma invoices

### DIFF
--- a/packages/core/src/protocol/PayRequest.ts
+++ b/packages/core/src/protocol/PayRequest.ts
@@ -27,6 +27,11 @@ const V1PayRequestSchema = z
      * the comment must be less than or equal to the value of `commentAllowed`.
      */
     comment: optionalIgnoringNull(z.string()),
+    /**
+     * InvoiceUUID is the invoice UUID that the sender is paying.
+     * This only exists in the v1 pay request since the v0 SDK won't support invoices.
+     */
+    invoiceUUID: optionalIgnoringNull(z.string().uuid())
   })
   .passthrough()
   .refine((data) => {
@@ -126,6 +131,10 @@ export class PayRequest {
      * the comment must be less than or equal to the value of `commentAllowed`.
      */
     public readonly comment?: string | undefined,
+    /**
+     * Associated UMA Invoice UUID
+     */
+    public readonly invoiceUUID?: string | undefined
   ) {}
 
   /**

--- a/packages/core/src/protocol/PayRequest.ts
+++ b/packages/core/src/protocol/PayRequest.ts
@@ -31,7 +31,7 @@ const V1PayRequestSchema = z
      * InvoiceUUID is the invoice UUID that the sender is paying.
      * This only exists in the v1 pay request since the v0 SDK won't support invoices.
      */
-    invoiceUUID: optionalIgnoringNull(z.string().uuid())
+    invoiceUUID: optionalIgnoringNull(z.string().uuid()),
   })
   .passthrough()
   .refine((data) => {
@@ -134,7 +134,7 @@ export class PayRequest {
     /**
      * Associated UMA Invoice UUID
      */
-    public readonly invoiceUUID?: string | undefined
+    public readonly invoiceUUID?: string | undefined,
   ) {}
 
   /**

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -426,6 +426,11 @@ type GetPayRequestArgs = {
    * LUD-21 spec, this should be 1.
    */
   umaMajorVersion: number;
+
+  /**
+   * associated invoice id, for PayRequest version1+
+   */
+  invoiceUUID?: string | undefined
 };
 
 /**
@@ -449,6 +454,7 @@ export async function getPayRequest({
   requestedPayeeData,
   comment,
   umaMajorVersion,
+  invoiceUUID
 }: GetPayRequestArgs): Promise<PayRequest> {
   const complianceData = await getSignedCompliancePayerData(
     receiverEncryptionPubKey,
@@ -478,6 +484,7 @@ export async function getPayRequest({
     },
     requestedPayeeData,
     comment,
+    invoiceUUID
   );
 }
 
@@ -654,11 +661,13 @@ export async function getPayReqResponse({
     ? Math.round((request.amount - receiverFeesMillisats) / conversionRate)
     : request.amount;
 
+  const encodedInvoiceUUID = request.invoiceUUID ?? JSON.stringify(request.invoiceUUID);
+
   const encodedPayerData =
     request.payerData && JSON.stringify(request.payerData);
   const encodedInvoice = await invoiceCreator.createUmaInvoice(
     msatsAmount,
-    metadata + (encodedPayerData || ""),
+    metadata + (encodedPayerData || "") + (encodedInvoiceUUID),
     payeeIdentifier,
   );
   if (!encodedInvoice) {


### PR DESCRIPTION
this pr adds invoiceUUID to PayReq, and encodes it as a json list as part of PayReqResponse metadata