### PR TITLE
[uma-auth] handle back navigation and error edge cases

### DIFF
--- a/examples/react/src/Root.tsx
+++ b/examples/react/src/Root.tsx
@@ -19,4 +19,10 @@ export function Root() {
 
 const Container = styled.div`
   background-color: ${({ theme }) => theme.bg};
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 `;

--- a/packages/uma-auth-client/src/components/UmaConnectButton.tsx
+++ b/packages/uma-auth-client/src/components/UmaConnectButton.tsx
@@ -26,6 +26,7 @@ const UmaConnectButton = (props: Props) => {
     isConnectionValid,
     oAuthTokenExchange,
     setAuthConfig,
+    clearUserAuth,
   } = useOAuth();
 
   const isConnected = isConnectionValid();
@@ -54,10 +55,18 @@ const UmaConnectButton = (props: Props) => {
       step !== Step.ErrorConnecting
     ) {
       setStep(Step.WaitingForApproval);
-      oAuthTokenExchange().catch((e) => {
-        console.error(e);
-        setStep(Step.ErrorConnecting);
-      });
+
+      // Only perform oauth token exchange if the code and state are present in the URL
+      const urlParams = new URLSearchParams(window.location.search);
+      const code = urlParams.get("code");
+      const state = urlParams.get("state");
+      if (code && state) {
+        oAuthTokenExchange().catch((e) => {
+          console.error(e);
+          clearUserAuth();
+          setStep(Step.ErrorConnecting);
+        });
+      }
       shouldOpenModalImmediately = true;
     } else if (isConnected && step === Step.WaitingForApproval) {
       setStep(Step.DoneConnecting);
@@ -76,6 +85,7 @@ const UmaConnectButton = (props: Props) => {
     isConnected,
     step,
     isModalOpen,
+    clearUserAuth,
     oAuthTokenExchange,
     setStep,
     setIsModalOpen,

--- a/packages/uma-auth-client/src/hooks/useModalState.tsx
+++ b/packages/uma-auth-client/src/hooks/useModalState.tsx
@@ -10,16 +10,31 @@ interface ModalState {
 }
 
 export const useModalState = create<ModalState>((set) => ({
-  step: Step.Connect,
+  step: Step.Empty,
   setStep: (step) => set({ step }),
   onBack: () =>
     set(({ step }) => {
       const stepInfo = STEP_MAP[step];
+      if (stepInfo.onBack) {
+        stepInfo.onBack();
+      }
       if (stepInfo.prev) {
         return { step: stepInfo.prev };
       }
       return { step };
     }),
   isModalOpen: false,
-  setIsModalOpen: (isModalOpen) => set({ isModalOpen }),
+  setIsModalOpen: (isModalOpen) =>
+    set((state) => {
+      const stepInfo = STEP_MAP[state.step];
+      if (
+        state.isModalOpen === true &&
+        isModalOpen === false &&
+        stepInfo.onClose
+      ) {
+        stepInfo.onClose();
+      }
+
+      return { isModalOpen };
+    }),
 }));

--- a/packages/uma-auth-client/src/hooks/useOAuth.tsx
+++ b/packages/uma-auth-client/src/hooks/useOAuth.tsx
@@ -106,6 +106,7 @@ export const useOAuth = create<OAuthState>()(
         return true;
       },
       clearUserAuth: () => {
+        deleteCodeAndStateFromUrl();
         set({
           token: undefined,
           nwcConnectionUri: undefined,
@@ -291,6 +292,8 @@ const oAuthTokenExchange = async (state: OAuthState) => {
     resultToken = processAsUmaAuthToken(result);
   }
 
+  deleteCodeAndStateFromUrl();
+
   return {
     codeVerifier: "",
     token: {
@@ -352,4 +355,11 @@ const processAsUmaAuthToken = (
   }
 
   return umaToken;
+};
+
+const deleteCodeAndStateFromUrl = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.delete("code");
+  url.searchParams.delete("state");
+  window.history.replaceState({}, document.title, url.toString());
 };

--- a/packages/uma-auth-client/src/steps/ConnectUma.tsx
+++ b/packages/uma-auth-client/src/steps/ConnectUma.tsx
@@ -12,8 +12,9 @@ import { setLocalStorage } from "src/utils/localStorage";
 export const ConnectUma = () => {
   const { setStep } = useModalState();
   const { uma, setUma } = useUser();
-  const { initialOAuthRequest } = useOAuth();
+  const { initialOAuthRequest, clearUserAuth } = useOAuth();
   const [isLoading, setIsLoading] = useState(false);
+
   const handleChangeUma = (value: string) => {
     setUma(`$${value}`);
   };
@@ -29,6 +30,7 @@ export const ConnectUma = () => {
     if (success) {
       setStep(Step.WaitingForApproval);
     } else {
+      clearUserAuth();
       setStep(Step.ErrorConnecting);
     }
     setIsLoading(false);

--- a/packages/uma-auth-client/src/steps/WaitingForApproval.tsx
+++ b/packages/uma-auth-client/src/steps/WaitingForApproval.tsx
@@ -1,11 +1,28 @@
 import styled from "@emotion/styled";
+import { Button } from "@lightsparkdev/ui/components";
 import { Body } from "@lightsparkdev/ui/components/typography/Body";
 import { Title } from "@lightsparkdev/ui/components/typography/Title";
+import { useState } from "react";
 import { UmaDisplay } from "src/components/UmaDisplay";
+import { useModalState } from "src/hooks/useModalState";
 import { useUser } from "src/hooks/useUser";
+import { useOAuth } from "src/main";
+import { Step } from "src/types";
 
 export const WaitingForApproval = () => {
   const { uma } = useUser();
+  const { initialOAuthRequest, clearUserAuth } = useOAuth();
+  const { setStep } = useModalState();
+  const [isLoadingRetry, setIsLoadingRetry] = useState(false);
+
+  const handleRetry = async () => {
+    setIsLoadingRetry(true);
+    const { success } = await initialOAuthRequest(uma!);
+    if (!success) {
+      clearUserAuth();
+      setStep(Step.ErrorConnecting);
+    }
+  };
 
   return (
     <Container>
@@ -18,6 +35,13 @@ export const WaitingForApproval = () => {
           color={["content", "secondary"]}
         />
       </TextContainer>
+      <Button
+        text="Retry"
+        kind="secondary"
+        fullWidth
+        onClick={handleRetry}
+        loading={isLoadingRetry}
+      />
     </Container>
   );
 };

--- a/packages/uma-auth-client/src/types.ts
+++ b/packages/uma-auth-client/src/types.ts
@@ -1,3 +1,4 @@
+import { useOAuth } from "./main";
 import { ConnectUma } from "./steps/ConnectUma";
 import { ConnectedWallet } from "./steps/ConnectedWallet";
 import { DoneConnecting } from "./steps/DoneConnecting";
@@ -10,6 +11,7 @@ import { WaitingForApproval } from "./steps/WaitingForApproval";
 import { WhatIsUma } from "./steps/WhatIsUma";
 
 export enum Step {
+  Empty = "Empty",
   Connect = "Connect",
   MoreOptions = "MoreOptions",
   NostrWalletConnect = "NostrWalletConnect",
@@ -27,9 +29,14 @@ interface StepInfo {
   component: React.ComponentType;
   title?: string;
   prev?: Step;
+  onBack?: () => void;
+  onClose?: () => void;
 }
 
 export const STEP_MAP: Record<Step, StepInfo> = {
+  [Step.Empty]: {
+    component: () => null,
+  },
   [Step.Connect]: {
     component: ConnectUma,
   },
@@ -55,6 +62,12 @@ export const STEP_MAP: Record<Step, StepInfo> = {
     component: WaitingForApproval,
     title: "Waiting for approval",
     prev: Step.Connect,
+    onBack: () => {
+      useOAuth.getState().clearUserAuth();
+    },
+    onClose: () => {
+      useOAuth.getState().clearUserAuth();
+    },
   },
   [Step.Unavailable]: {
     component: Unavailable,


### PR DESCRIPTION
<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/NU8OmLauzLqa61yWDJkY/843798b2-de6f-4dc0-8222-d061384cf62e.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/NU8OmLauzLqa61yWDJkY/843798b2-de6f-4dc0-8222-d061384cf62e.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/843798b2-de6f-4dc0-8222-d061384cf62e.mov">Screen Recording 2024-09-25 at 2.55.22 PM.mov</video>

Edge cases tested:
    - click button to open modal
    - click connect (should show loading button and then loading screen)
    - if there is an error, should show error screen and clear auth state
    - going back from permission page should show loading screen
        - refreshing should keep showing loading screen
        - going back on loading screen should clear auth state
        - closing loading screen should clear auth state
        - retry on loading screen should make initial auth request again and redirect to permissions page
    - confirming permissions page should navigate back to loading screen
    - loading screen should change to success screen
    - if there is an error, should show error screen and clear auth state
    - uma connect button should now show uma and be connected

- Added a retry button to loading screen
- Removes code and state from url upon clearing auth state or finishing token exchange 