### PR TITLE
[uma-auth] prevent styles from being inherited in uma-connect-button

### DIFF
--- a/packages/uma-auth-client/src/components/UmaConnectButton.tsx
+++ b/packages/uma-auth-client/src/components/UmaConnectButton.tsx
@@ -188,5 +188,5 @@ const ButtonContents = styled.div`
 defineWebComponent(TAG_NAME, UmaConnectButton);
 
 export const UmaConnectButtonWebComponent = (props: Record<string, any>) => (
-  <uma-connect-button {...props} />
+  <uma-connect-button {...props} style={{ all: "initial" }} />
 );


### PR DESCRIPTION
In the shadow dom, styles are actually still inherited; it's just selectors that don't work,
e.g.
```
span {
    color: blue;
}
```
would not affect elements in a shadow dom.

But if, for example, `text-align: center;` is specified in an element containing the shadow dom element, that style is still inherited.

The general recommendation seems to be just setting `all: initial;` on the host element (in this case the web component)