### PR TITLE
[core] Make agnostic to environment. Fix isValidUmaAddress

### DIFF
--- a/packages/core/src/certUtils.ts
+++ b/packages/core/src/certUtils.ts
@@ -1,13 +1,19 @@
-import { X509Certificate } from "crypto";
+import * as crypto from "crypto";
 import { InvalidInputError } from "./errors.js";
 
+type X509Certificate = crypto.X509Certificate;
+
 export const getX509CertChain = (certChain: string) => {
+  if (!crypto.X509Certificate) {
+    throw new Error("X509Certificate is only available in Node.js");
+  }
+
   const certs = certChain
     .split("-----END CERTIFICATE-----")
     .filter((cert) => cert.trim().length > 0)
     .map((cert) => `${cert.trim()}\n-----END CERTIFICATE-----\n`);
   try {
-    return certs.map((cert) => new X509Certificate(cert));
+    return certs.map((cert) => new crypto.X509Certificate(cert));
   } catch (e) {
     throw new InvalidInputError("Cannot be parsed as a valid X509 certificate");
   }

--- a/packages/core/src/createHash.ts
+++ b/packages/core/src/createHash.ts
@@ -1,0 +1,34 @@
+import { isBrowser } from "./environment.js";
+import { bytesToHex } from "./hex.js";
+
+type SourceData = Uint8Array | string;
+
+export async function createSha256Hash(data: SourceData): Promise<Uint8Array>;
+export async function createSha256Hash(
+  data: SourceData,
+  asHex: true,
+): Promise<string>;
+
+export async function createSha256Hash(
+  data: SourceData,
+  asHex?: boolean,
+): Promise<Uint8Array | string> {
+  if (isBrowser) {
+    const source =
+      typeof data === "string" ? new TextEncoder().encode(data) : data;
+    const buffer = await window.crypto.subtle.digest("SHA-256", source);
+    const arr = new Uint8Array(buffer);
+    if (asHex) {
+      return bytesToHex(arr);
+    }
+    return arr;
+  } else {
+    const { createHash } = await import("crypto");
+    if (asHex) {
+      const hexStr = createHash("sha256").update(data).digest("hex");
+      return hexStr;
+    }
+    const buffer = createHash("sha256").update(data).digest();
+    return new Uint8Array(buffer);
+  }
+}

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,0 +1,9 @@
+export const isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined";
+
+export const isNode =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.versions.node != null;
+
+export const isTest = isNode && process.env.NODE_ENV === "test";

--- a/packages/core/src/hex.ts
+++ b/packages/core/src/hex.ts
@@ -1,0 +1,15 @@
+export const bytesToHex = (bytes: Uint8Array): string => {
+  return bytes.reduce((acc: string, byte: number) => {
+    return (acc += ("0" + byte.toString(16)).slice(-2));
+  }, "");
+};
+
+export const hexToBytes = (hex: string): Uint8Array => {
+  const bytes: number[] = [];
+
+  for (let c = 0; c < hex.length; c += 2) {
+    bytes.push(parseInt(hex.substr(c, 2), 16));
+  }
+
+  return Uint8Array.from(bytes);
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./createHash.js";
 export * from "./NonceValidator.js";
 export * from "./protocol/CounterPartyData.js";
 export * from "./protocol/Currency.js";

--- a/packages/core/src/protocol/PubKeyResponse.ts
+++ b/packages/core/src/protocol/PubKeyResponse.ts
@@ -1,5 +1,7 @@
-import { X509Certificate } from "crypto";
+import * as crypto from "crypto";
 import { getPublicKey } from "../certUtils.js";
+
+type X509Certificate = crypto.X509Certificate;
 
 /** PubKeyResponse is sent from a VASP to another VASP to provide its public keys. It is the response to GET requests at `/.well-known/lnurlpubkey`. */
 export class PubKeyResponse {
@@ -60,12 +62,17 @@ export class PubKeyResponse {
 
   static fromJson(jsonStr: string): PubKeyResponse {
     const jsonObject = JSON.parse(jsonStr);
+
+    if (!crypto.X509Certificate) {
+      throw new Error("X509Certificate is only available in Node.js");
+    }
+
     return new PubKeyResponse(
       jsonObject.signingCertChain?.map(
-        (cert: string) => new X509Certificate(Buffer.from(cert, "hex")),
+        (cert: string) => new crypto.X509Certificate(Buffer.from(cert, "hex")),
       ),
       jsonObject.encryptionCertChain?.map(
-        (cert: string) => new X509Certificate(Buffer.from(cert, "hex")),
+        (cert: string) => new crypto.X509Certificate(Buffer.from(cert, "hex")),
       ),
       jsonObject.signingPubKey,
       jsonObject.encryptionPubKey,

--- a/packages/core/src/tests/uma.test.ts
+++ b/packages/core/src/tests/uma.test.ts
@@ -295,6 +295,7 @@ describe("uma", () => {
     expect(isValidUmaAddress("bob@vasp-domain.com")).toBe(false);
     expect(isValidUmaAddress("bob@vasp-domain")).toBe(false);
     expect(isValidUmaAddress("$%@vasp-domain.com")).toBe(false);
+    expect(isValidUmaAddress("$bob@")).toBe(false);
     expect(
       isValidUmaAddress(
         "$therearemorethan64charactersinthisusername12345678912345678912345@vasp-domain.com",

--- a/packages/core/src/uma.ts
+++ b/packages/core/src/uma.ts
@@ -1,7 +1,8 @@
-import crypto, { createHash } from "crypto";
+import crypto from "crypto";
 import { encrypt, PublicKey } from "eciesjs";
 import secp256k1 from "secp256k1";
 import { getPublicKey, getX509CertChain } from "./certUtils.js";
+import { createSha256Hash } from "./createHash.js";
 import { InvalidInputError } from "./errors.js";
 import { type NonceValidator } from "./NonceValidator.js";
 import { type CounterPartyDataOptions } from "./protocol/CounterPartyData.js";
@@ -46,13 +47,6 @@ import {
   UmaProtocolVersion,
   UnsupportedVersionError,
 } from "./version.js";
-
-export const createSha256Hash = async (
-  data: Uint8Array,
-): Promise<Uint8Array> => {
-  const buffer = createHash("sha256").update(data).digest();
-  return new Uint8Array(buffer);
-};
 
 export function parseLnurlpRequest(url: URL): LnurlpRequest {
   const query = url.searchParams;
@@ -355,6 +349,11 @@ export function isValidUmaAddress(umaAddress: string) {
 
   const userName = addressParts[0].slice(1);
   if (!userName.match(/^[a-z0-9-_\.\+]+$/i)) {
+    return false;
+  }
+
+  const domain = addressParts[1];
+  if (!domain.match(/^[a-z0-9-\.]+$/i)) {
     return false;
   }
 


### PR DESCRIPTION
I want to use isValidUmaAddress in a browser environment, and it seems likely that some utils or types may be helpful to have client side in the future. This resolves some Node.js specific dependencies so that the package can be bundled for browser.